### PR TITLE
Bundle currency and country data in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ yarn add country-currency-utils
 
 ## Countries and Currencies data
 
-The package hosts country and currency data via CDN URLs:
+The package bundles country and currency data locally:
 
-`COUNTRIES_DETAILS_URL`, `CURRENCIES_DETAILS_URL`
+- `data/countries.json`
+- `data/currencies.json`
+
+For convenience, the same data is also available via CDN:
 
 - **Countries:** [Countries JSON](https://cdn.jsdelivr.net/gh/headlesstech/country-currency-utils@main/data/countries.json)
 - **Currencies:** [Currencies JSON](https://cdn.jsdelivr.net/gh/headlesstech/country-currency-utils@main/data/currencies.json)
@@ -61,7 +64,7 @@ type TCountryData = TCountryDetails & {
 _Reference_
 
 ```typescript
-getAllCountryDetails(): Promise<Record<string, TCountryDetails>>
+getAllCountryDetails(): Record<string, TCountryDetails>
 ```
 
 Return all country details in Object format. The `key` in object is Country Code (ISO 3166).
@@ -71,7 +74,7 @@ Return all country details in Object format. The `key` in object is Country Code
 _Reference_
 
 ```typescript
-getAllCountryData(): Promise<TCountryData[]>
+getAllCountryData(): TCountryData[]
 ```
 
 Return all country data in array format.
@@ -81,7 +84,7 @@ Return all country data in array format.
 _Reference_
 
 ```typescript
-getCountryData(countryCode: string): Promise<TCountryData | undefined>
+getCountryData(countryCode: string): TCountryData | undefined
 ```
 
 Return country data given a country code.
@@ -89,7 +92,7 @@ Return country data given a country code.
 _Example:_
 
 ```typescript
-const countryData = await getCountryData("BD");
+const countryData = getCountryData("BD");
 ```
 
 #### `getCountriesData`
@@ -97,7 +100,7 @@ const countryData = await getCountryData("BD");
 _Reference_
 
 ```typescript
-getCountriesData(countryCodes: string[]): Promise<(TCountryData | undefined)[]>
+getCountriesData(countryCodes: string[]): (TCountryData | undefined)[]
 ```
 
 Return multiple countries data given array of country codes.
@@ -105,7 +108,7 @@ Return multiple countries data given array of country codes.
 _Example:_
 
 ```typescript
-const countriesData = await getCountriesData(["US", "BD"]);
+const countriesData = getCountriesData(["US", "BD"]);
 ```
 
 ---
@@ -142,7 +145,7 @@ type TCurrencyData = TCurrencyDetails & {
 _Reference_
 
 ```typescript
-getAllCurrencyDetails(): Promise<Record<string, TCurrencyDetails>>
+getAllCurrencyDetails(): Record<string, TCurrencyDetails>
 ```
 
 Return all currency details in Object format. The `key` in object is Currency Code (ISO 4217).
@@ -152,7 +155,7 @@ Return all currency details in Object format. The `key` in object is Currency Co
 _Reference_
 
 ```typescript
-getAllCurrencyData(): Promise<TCurrencyData[]>
+getAllCurrencyData(): TCurrencyData[]
 ```
 
 Return all currency data in array format.
@@ -162,7 +165,7 @@ Return all currency data in array format.
 _Reference_
 
 ```typescript
-getCurrencyData(currencyCode: string): Promise<TCurrencyData | undefined>
+getCurrencyData(currencyCode: string): TCurrencyData | undefined
 ```
 
 Returns Currency data given a currency code
@@ -170,7 +173,7 @@ Returns Currency data given a currency code
 _Example:_
 
 ```typescript
-const currencyData = await getCurrencyData("BDT");
+const currencyData = getCurrencyData("BDT");
 ```
 
 #### `getCurrenciesData`
@@ -178,15 +181,15 @@ const currencyData = await getCurrencyData("BDT");
 _Reference_
 
 ```typescript
-getCurrenciesData(currencyCodes: string[]): Promise<(TCurrencyData | undefined)[]>
+getCurrenciesData(currencyCodes: string[]): (TCurrencyData | undefined)[]
 ```
 
-Returns Currencies data given am array of currency codes
+Returns Currencies data given an array of currency codes
 
 _Example:_
 
 ```typescript
-const currenciesData = await getCurrenciesData(["USD", "BDT"]);
+const currenciesData = getCurrenciesData(["USD", "BDT"]);
 ```
 
 ---
@@ -230,8 +233,8 @@ This uses the `getFixedAmount` function internally to ceil/round on details of a
 _Example:_
 
 ```typescript
-const USDCurrencyData = await getCurrencyData("USD");
-const BDTCurrencyData = await getCurrencyData("BDT");
+const USDCurrencyData = getCurrencyData("USD");
+const BDTCurrencyData = getCurrencyData("BDT");
 
 const roundedAmount = getFixedAmountOnCurrency(123.4567, USDCurrencyData); // 123.46
 const roundedAmount = getFixedAmountOnCurrency(123.45, BDTCurrencyData); // 123.45
@@ -239,9 +242,6 @@ const roundedAmount = getFixedAmountOnCurrency(123.45, BDTCurrencyData, {
   roundingDecimals: "compact",
 }); // 124
 ```
-
-**Note:**
-You will notice that we are having to run a promise to get CurrencyData and then round/format/display monetory amount. When handling many countries and currencies, it is better to fetch data and then use it, rather that keeping a list of countries and currencies as data or as constant in code base. This keeps codebase light. However if you are handling single currency or just a few currencies. You can keep a list of currencies data and use it directly in function in stead of fetching through an async call.
 
 #### `getFormattedAmount`
 
@@ -276,8 +276,8 @@ Formats the given amount according to the currency's standard decimal places and
 _Example:_
 
 ```typescript
-const USDCurrencyData = await getCurrencyData("USD");
-const BDTCurrencyData = await getCurrencyData("BDT");
+const USDCurrencyData = getCurrencyData("USD");
+const BDTCurrencyData = getCurrencyData("BDT");
 
 const formattedAmount = getFormattedAmountOnCurrency(123456.7, USDCurrencyData); // "123,456.70"
 const formattedAmount = getFormattedAmountOnCurrency(
@@ -321,8 +321,8 @@ Returns a displayable amount with currency symbol, rounded by default and uses p
 _Example:_
 
 ```typescript
-const USDCurrencyData = await getCurrencyData("USD");
-const BDTCurrencyData = await getCurrencyData("BDT");
+const USDCurrencyData = getCurrencyData("USD");
+const BDTCurrencyData = getCurrencyData("BDT");
 
 const displayAmount = getDisplayAmountOnCurrency(123.4567, USDCurrencyData); // "$ 123.46"
 const displayAmount = getDisplayAmountOnCurrency(123456.7, USDCurrencyData); // "$ 123,456.70"
@@ -341,7 +341,7 @@ const displayAmount = getDisplayAmountOnCurrency(123, BDTCurrencyData, {
 #### `getDisplayAmountOnCurrencyCode`
 
 ```typescript
-getDisplayAmountOnCurrencyCode(amount: number, currencyCode: string, options?: TCurrencyFormatOptions): Promise<string>
+getDisplayAmountOnCurrencyCode(amount: number, currencyCode: string, options?: TCurrencyFormatOptions): string
 ```
 
 Returns a displayable amount with currency symbol, using the `getDisplayAmountOnCurrency` function and looks up currency details on currency code
@@ -349,16 +349,16 @@ Returns a displayable amount with currency symbol, using the `getDisplayAmountOn
 _Example:_
 
 ```typescript
-const displayAmount = await getDisplayAmountOnCurrencyCode(123.4567, "USD"); // "$ 123.46"
-const displayAmount = await getDisplayAmountOnCurrencyCode(123456.7, "USD"); // "$ 123,456.70"
-const displayAmount = await getDisplayAmountOnCurrencyCode(123456.7, "USD", {
+const displayAmount = getDisplayAmountOnCurrencyCode(123.4567, "USD"); // "$ 123.46"
+const displayAmount = getDisplayAmountOnCurrencyCode(123456.7, "USD"); // "$ 123,456.70"
+const displayAmount = getDisplayAmountOnCurrencyCode(123456.7, "USD", {
   avoidFormat: true,
 }); // "$ 123456.7"
-const displayAmount = await getDisplayAmountOnCurrencyCode(123456.7, "USD", {
+const displayAmount = getDisplayAmountOnCurrencyCode(123456.7, "USD", {
   separator: "",
 }); // "$123,456.70"
-const displayAmount = await getDisplayAmountOnCurrencyCode(123.4567, "BDT"); // "Tk 123.46"
-const displayAmount = await getDisplayAmountOnCurrencyCode(123, "BDT", {
+const displayAmount = getDisplayAmountOnCurrencyCode(123.4567, "BDT"); // "Tk 123.46"
+const displayAmount = getDisplayAmountOnCurrencyCode(123, "BDT", {
   isSymbolStandard: true,
 }); // "৳ 123"
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "data"
   ],
   "scripts": {
     "build": "tsup",

--- a/src/countries.ts
+++ b/src/countries.ts
@@ -1,3 +1,5 @@
+import countriesData from "../data/countries.json";
+
 // Country data in json format
 // Hosted through this repo
 // check data folder for JSON file
@@ -19,18 +21,15 @@ export type TCountryData = TCountryDetails & {
 /*
   Fetch all country details (object format)
 */
-export async function getAllCountryDetails(): Promise<
-  Record<string, TCountryDetails>
-> {
-  const response = await fetch(COUNTRIES_DETAILS_URL);
-  return response.json();
+export function getAllCountryDetails(): Record<string, TCountryDetails> {
+  return countriesData as Record<string, TCountryDetails>;
 }
 
 /*
   Fetch all country data (array format)
 */
-export async function getAllCountryData(): Promise<TCountryData[]> {
-  const countryDetails = await getAllCountryDetails();
+export function getAllCountryData(): TCountryData[] {
+  const countryDetails = getAllCountryDetails();
   return Object.keys(countryDetails).map((countryCode) => ({
     countryCode,
     ...countryDetails[countryCode],
@@ -40,10 +39,8 @@ export async function getAllCountryData(): Promise<TCountryData[]> {
 /*
   Fetch country data on a single country code
 */
-export async function getCountryData(
-  countryCode: string
-): Promise<TCountryData | undefined> {
-  const allCountryDetails = await getAllCountryDetails();
+export function getCountryData(countryCode: string): TCountryData | undefined {
+  const allCountryDetails = getAllCountryDetails();
   const countryDetails = allCountryDetails[countryCode];
 
   if (!countryDetails) return;
@@ -57,10 +54,10 @@ export async function getCountryData(
 /*
   Fetch countries on multiple country codes
 */
-export async function getCountriesData(
+export function getCountriesData(
   countryCodes: string[]
-): Promise<(TCountryData | undefined)[]> {
-  const allCountryDetails = await getAllCountryDetails();
+): (TCountryData | undefined)[] {
+  const allCountryDetails = getAllCountryDetails();
 
   return countryCodes.map((countryCode) => {
     const countryDetails = allCountryDetails[countryCode];

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -1,3 +1,5 @@
+import currenciesData from "../data/currencies.json";
+
 // Currencies data in json format
 // Hosted through this repo
 // check data folder for JSON file
@@ -31,18 +33,15 @@ export type TCurrencyData = TCurrencyDetails & {
 /*
   Fetch all currency details (object format)
 */
-export async function getAllCurrencyDetails(): Promise<
-  Record<string, TCurrencyDetails>
-> {
-  const response = await fetch(CURRENCIES_DETAILS_URL);
-  return response.json();
+export function getAllCurrencyDetails(): Record<string, TCurrencyDetails> {
+  return currenciesData as Record<string, TCurrencyDetails>;
 }
 
 /*
   Fetch all currency data (array format)
 */
-export async function getAllCurrencyData(): Promise<TCurrencyData[]> {
-  const currencyDetails = await getAllCurrencyDetails();
+export function getAllCurrencyData(): TCurrencyData[] {
+  const currencyDetails = getAllCurrencyDetails();
   return Object.keys(currencyDetails).map((currencyCode) => ({
     currencyCode,
     ...currencyDetails[currencyCode],
@@ -52,10 +51,10 @@ export async function getAllCurrencyData(): Promise<TCurrencyData[]> {
 /*
   Fetch currency data on a single currency code
 */
-export async function getCurrencyData(
+export function getCurrencyData(
   currencyCode: string
-): Promise<TCurrencyData | undefined> {
-  const allCurrencyDetails = await getAllCurrencyDetails();
+): TCurrencyData | undefined {
+  const allCurrencyDetails = getAllCurrencyDetails();
   const currencyDetails = allCurrencyDetails[currencyCode];
 
   if (!currencyDetails) return;
@@ -69,10 +68,10 @@ export async function getCurrencyData(
 /*
   Fetch currencies on multiple currency codes
 */
-export async function getCurrenciesData(
+export function getCurrenciesData(
   currencyCodes: string[]
-): Promise<(TCurrencyData | undefined)[]> {
-  const allCurrencyDetails = await getAllCurrencyDetails();
+): (TCurrencyData | undefined)[] {
+  const allCurrencyDetails = getAllCurrencyDetails();
 
   return currencyCodes.map((currencyCode) => {
     const currencyDetails = allCurrencyDetails[currencyCode];

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -15,9 +15,9 @@ import {
   Check all currencies listed under country
   exists in currencies map
 */
-test("country to currency match", async () => {
-  const allCountriesDetails = await getAllCountryDetails();
-  const allCurrenciesDetails = await getAllCurrencyDetails();
+test("country to currency match", () => {
+  const allCountriesDetails = getAllCountryDetails();
+  const allCurrenciesDetails = getAllCurrencyDetails();
 
   const leftOutCountryCodes: string[] = [];
 
@@ -59,9 +59,9 @@ test("Test amount rounding", () => {
 /*
   Rounding amount on currency test
 */
-test("Test amount rounding on currency", async () => {
-  const USDCurrencyDetails = await getCurrencyData("USD");
-  const BDTCurrencyDetails = await getCurrencyData("BDT");
+test("Test amount rounding on currency", () => {
+  const USDCurrencyDetails = getCurrencyData("USD");
+  const BDTCurrencyDetails = getCurrencyData("BDT");
 
   expect(USDCurrencyDetails).toBeDefined();
   expect(BDTCurrencyDetails).toBeDefined();
@@ -179,8 +179,8 @@ test("Test amount formatting", () => {
 /*
   Formatting amount on currency test
 */
-test("Test amount formatting on currency", async () => {
-  const [USDCurrencyDetails, BDTCurrencyDetails] = await getCurrenciesData([
+test("Test amount formatting on currency", () => {
+  const [USDCurrencyDetails, BDTCurrencyDetails] = getCurrenciesData([
     "USD",
     "BDT",
   ]);
@@ -307,9 +307,9 @@ test("Test amount formatting on currency", async () => {
 /*
   Display amount on currency
 */
-test("Test amount display on currency", async () => {
-  const USDCurrencyDetails = await getCurrencyData("USD");
-  const BDTCurrencyDetails = await getCurrencyData("BDT");
+test("Test amount display on currency", () => {
+  const USDCurrencyDetails = getCurrencyData("USD");
+  const BDTCurrencyDetails = getCurrencyData("BDT");
 
   expect(USDCurrencyDetails).toBeDefined();
   expect(BDTCurrencyDetails).toBeDefined();
@@ -434,63 +434,63 @@ test("Test amount display on currency", async () => {
 /*
   Display amount on currency code
 */
-test("Test amount display on currency code", async () => {
+test("Test amount display on currency code", () => {
   // USD
-  expect(await getDisplayAmountOnCurrencyCode(1.123, "USD")).toBe("$ 1.13");
-  expect(await getDisplayAmountOnCurrencyCode(1234.12, "USD")).toBe(
+  expect(getDisplayAmountOnCurrencyCode(1.123, "USD")).toBe("$ 1.13");
+  expect(getDisplayAmountOnCurrencyCode(1234.12, "USD")).toBe(
     "$ 1,234.12"
   );
   expect(
-    await getDisplayAmountOnCurrencyCode(1234.12, "USD", {
+    getDisplayAmountOnCurrencyCode(1234.12, "USD", {
       avoidFormat: true,
     })
   ).toBe("$ 1234.12");
   expect(
-    await getDisplayAmountOnCurrencyCode(1234.1234, "USD", {
+    getDisplayAmountOnCurrencyCode(1234.1234, "USD", {
       avoidFormat: true,
       avoidRound: true,
     })
   ).toBe("$ 1234.1234");
-  expect(await getDisplayAmountOnCurrencyCode(1234.1, "USD")).toBe(
+  expect(getDisplayAmountOnCurrencyCode(1234.1, "USD")).toBe(
     "$ 1,234.10"
   );
-  expect(await getDisplayAmountOnCurrencyCode(1234.1, "USD")).toBe(
+  expect(getDisplayAmountOnCurrencyCode(1234.1, "USD")).toBe(
     "$ 1,234.10"
   );
   expect(
-    await getDisplayAmountOnCurrencyCode(1234.1, "USD", {
+    getDisplayAmountOnCurrencyCode(1234.1, "USD", {
       avoidFormat: true,
     })
   ).toBe("$ 1234.1");
 
   // BDT
-  expect(await getDisplayAmountOnCurrencyCode(1.123, "BDT")).toBe("Tk 1.13");
+  expect(getDisplayAmountOnCurrencyCode(1.123, "BDT")).toBe("Tk 1.13");
   expect(
-    await getDisplayAmountOnCurrencyCode(1.123, "BDT", {
+    getDisplayAmountOnCurrencyCode(1.123, "BDT", {
       roundingDecimals: "compact",
     })
   ).toBe("Tk 2");
   expect(
-    await getDisplayAmountOnCurrencyCode(1.123, "BDT", {
+    getDisplayAmountOnCurrencyCode(1.123, "BDT", {
       isSymbolNative: true,
     })
   ).toBe("Tk 1.13");
   expect(
-    await getDisplayAmountOnCurrencyCode(1.123, "BDT", {
+    getDisplayAmountOnCurrencyCode(1.123, "BDT", {
       isSymbolStandard: true,
     })
   ).toBe("৳ 1.13");
 
   expect(
-    await getDisplayAmountOnCurrencyCode(1123, "BDT", {
+    getDisplayAmountOnCurrencyCode(1123, "BDT", {
       isSymbolStandard: true,
     })
   ).toBe("৳ 1,123");
   expect(
-    await getDisplayAmountOnCurrencyCode(1123, "BDT", { separator: "" })
+    getDisplayAmountOnCurrencyCode(1123, "BDT", { separator: "" })
   ).toBe("Tk1,123");
   expect(
-    await getDisplayAmountOnCurrencyCode(1123, "BDT", {
+    getDisplayAmountOnCurrencyCode(1123, "BDT", {
       separator: "-",
       avoidFormat: true,
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -174,11 +174,11 @@ export function getDisplayAmountOnCurrency(
     : `${currencySymbol}${separatorStr}${formattedAmount}`;
 }
 
-export async function getDisplayAmountOnCurrencyCode(
+export function getDisplayAmountOnCurrencyCode(
   amount: number,
   currencyCode: string,
   options?: TCurrencyDisplayOptions
-): Promise<string> {
-  const currencyData = await getCurrencyData(currencyCode);
+): string {
+  const currencyData = getCurrencyData(currencyCode);
   return getDisplayAmountOnCurrency(amount, currencyData, options);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,9 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"],
+  "include": ["src", "data"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   minify: true,
-  external: ["test/**/*", "data/**/*"],
+  external: ["test/**/*"],
+  publicDir: "data",
 });


### PR DESCRIPTION
# Overview
Updates the library to bundle country and currency data locally, removing asynchronous fetching and promise-based APIs in favour of synchronous, in-memory access.

Closes #3 

# Changes
* Country and currency data (`countries.json`, `currencies.json`) are now bundled locally and imported directly, eliminating the need for remote CDN fetching at runtime. All related functions have been converted from async to synchronous. 
* The `README.md` has been updated to reflect the new synchronous API, update usage examples, and clarify that data is now bundled locally but still available via CDN for convenience. Async/await examples and notes about promises have been removed.
* The `package.json` now includes the `data` directory in the published files to ensure bundled data is available to consumers.
* Tests are updated to use the new synchronous API.